### PR TITLE
Prefer ChatGPT.exe after OpenAI shell rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A single executable, `codex-launcher.exe`. It behaves as either:
 - **Installer** — when no `updater.json` sits next to it. Runs the wizard
   (mode → path → options → progress → done).
 - **Proxy** — when `updater.json` is present. Spawns the most recent
-  `Codex.exe` from `versions/<ver>/`, after an optional update check.
+  `ChatGPT.exe` (or legacy `Codex.exe`) from `versions/<ver>/`, after an
+  optional update check.
 
 Install layout:
 
@@ -136,7 +137,8 @@ Run `codex-launcher.exe --uninstall`. The flow:
 
 1. Validate the install root looks like ours (refuses to wipe a Desktop /
    Downloads / user-profile / Program Files / drive-root).
-2. Detect any running `Codex.exe` processes and prompt before terminating
+2. Detect any running `ChatGPT.exe`/`Codex.exe` processes from this install
+   and prompt before terminating
    them.
 3. Whitelist-delete only the things we placed: `versions/`, `downloads/`,
    `updater.json`, the Start Menu shortcut, the Add/Remove Programs

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -6,7 +6,7 @@
 //! metadata we don't need to run Codex standalone.
 //!
 //! Layout produced:
-//!   <install_root>/versions/<version>/Codex.exe
+//!   <install_root>/versions/<version>/ChatGPT.exe  (or Codex.exe on older builds)
 //!   <install_root>/versions/<version>/resources/app.asar
 //!   ...
 //!
@@ -106,11 +106,10 @@ pub fn extract_app(
         )
     })?;
 
-    let codex_exe = final_dir.join("Codex.exe");
-    if !codex_exe.exists() {
+    if crate::proxy::app_exe_in(&final_dir).is_none() {
         bail!(
-            "extracted tree has no Codex.exe at {} — MSIX layout changed?",
-            codex_exe.display()
+            "extracted tree has no ChatGPT.exe/Codex.exe under {} — MSIX layout changed?",
+            final_dir.display()
         );
     }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -329,20 +329,24 @@ fn same_file(a: &Path, b: &Path) -> bool {
 }
 
 /// (Re)create the Start Menu `.lnk` with icon pointing at this version's
-/// `Codex.exe`. No-op for Portable mode (link_path returns None).
+/// app shell. No-op for Portable mode (link_path returns None).
 fn write_shortcut(root: &Path, mode: InstallMode, version: &str) -> Result<()> {
     let Some(link) = shortcut::link_path(mode)? else {
         return Ok(());
     };
     let target = root.join("codex-launcher.exe");
-    let icon = root.join("versions").join(version).join("Codex.exe");
+    let ver_dir = root.join("versions").join(version);
+    let icon = crate::proxy::app_exe_in(&ver_dir)
+        .unwrap_or_else(|| ver_dir.join("ChatGPT.exe"));
     shortcut::create_or_update(&link, &target, &icon, "Codex (unofficial updater)", root)
 }
 
 /// (Re)write the Add/Remove Programs registry entry for the current install.
 fn write_registry(root: &Path, mode: InstallMode, version: &str) -> Result<()> {
     let launcher = root.join("codex-launcher.exe");
-    let icon = root.join("versions").join(version).join("Codex.exe");
+    let ver_dir = root.join("versions").join(version);
+    let icon = crate::proxy::app_exe_in(&ver_dir)
+        .unwrap_or_else(|| ver_dir.join("ChatGPT.exe"));
     let entry = registry::UninstallEntry {
         display_name: "Codex (unofficial updater)",
         display_version: version,

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn run_proxy(
     if auto_update {
         // Defensive re-check after elevation: Codex may have been restarted
         // between the unelevated prompt and this re-spawn.
-        if !prompt_kill_codex_for("updating") {
+        if !prompt_kill_codex_for("updating", &root) {
             // User aborted at the elevated prompt. Fall through to normal
             // proxy flow so the update banner is still shown.
             dark_window::install();
@@ -753,7 +753,7 @@ fn wire_proxy_ui(
                 // on versions/<oldver>/Codex.exe etc. prevent clean junction
                 // swap and the running instance wouldn't pick up the new
                 // version anyway. Prompt before doing anything destructive.
-                if !prompt_kill_codex_for("updating") {
+                if !prompt_kill_codex_for("updating", root.as_path()) {
                     ui.set_current_screen(10);
                     return;
                 }
@@ -1118,15 +1118,19 @@ fn show_when_ready(ui: &AppWindow) {
     });
 }
 
-/// If any `Codex.exe` processes are running, prompt the user to terminate
-/// them. Returns true if it's safe to proceed (nothing was running, or user
+/// If any app-shell processes from *this* install are running, prompt the
+/// user to terminate them. Scoped to `install_root/versions` so we don't
+/// touch a Microsoft Store ChatGPT install or a foreign Codex tree.
+///
+/// Returns true if it's safe to proceed (nothing was running, or user
 /// confirmed termination and all PIDs exited). Returns false if the user
 /// cancelled, or if termination failed — caller should abort the destructive
 /// operation.
 ///
 /// `action` is the verb used in the prompt, e.g. "updating" / "uninstalling".
-fn prompt_kill_codex_for(action: &str) -> bool {
-    let pids = proxy::find_codex_pids();
+fn prompt_kill_codex_for(action: &str, install_root: &std::path::Path) -> bool {
+    let versions_root = install_root.join("versions");
+    let pids = proxy::find_our_codex_pids(&versions_root);
     if pids.is_empty() {
         return true;
     }
@@ -1142,7 +1146,7 @@ fn prompt_kill_codex_for(action: &str) -> bool {
         return false;
     }
     proxy::terminate_pids(&pids, 5000);
-    let still = proxy::find_codex_pids();
+    let still = proxy::find_our_codex_pids(&versions_root);
     if !still.is_empty() {
         dialogs::error(&format!(
             "Failed to terminate {} Codex process(es). Aborting.",
@@ -1297,17 +1301,21 @@ fn int_to_fetcher(i: i32) -> Fetcher {
     }
 }
 
-/// Resolve the Codex.exe to launch.
+/// Resolve the Electron shell (`ChatGPT.exe` preferred, else `Codex.exe`) to
+/// launch.
 ///
 /// When `use_junction` is true: scan for the newest numeric-version dir,
 /// verify the junction points at it (self-heal via remove+recreate if not),
-/// and return the junction path (`versions/current/Codex.exe`). Launching
+/// and return the junction path (`versions/current/<shell>.exe`). Launching
 /// via the stable junction path is what lets user-applied AV exclusions
 /// survive updates.
 ///
 /// When `use_junction` is false, or the junction can't be established,
-/// return the newest numeric-version `Codex.exe` directly.
-fn latest_codex_exe(root: &std::path::Path, use_junction: bool) -> Option<std::path::PathBuf> {
+/// return the newest numeric-version shell directly.
+pub(crate) fn latest_codex_exe(
+    root: &std::path::Path,
+    use_junction: bool,
+) -> Option<std::path::PathBuf> {
     let versions = root.join("versions");
     let (newest_name, newest_exe) = newest_numeric_version(&versions)?;
 
@@ -1334,16 +1342,15 @@ fn latest_codex_exe(root: &std::path::Path, use_junction: bool) -> Option<std::p
         }
     }
 
-    let via_junction = link.join("Codex.exe");
-    if via_junction.exists() {
+    if let Some(via_junction) = proxy::app_exe_in(&link) {
         Some(via_junction)
     } else {
         Some(newest_exe)
     }
 }
 
-/// Scan `versions/` for the highest numeric-dotted dir containing `Codex.exe`.
-/// Returns `(dir_name, full_path_to_Codex.exe)`.
+/// Scan `versions/` for the highest numeric-dotted dir containing a known
+/// app shell. Returns `(dir_name, full_path_to_shell_exe)`.
 fn newest_numeric_version(versions: &std::path::Path) -> Option<(String, std::path::PathBuf)> {
     let mut best: Option<(Vec<u64>, String, std::path::PathBuf)> = None;
     for entry in std::fs::read_dir(versions).ok()? {
@@ -1359,13 +1366,12 @@ fn newest_numeric_version(versions: &std::path::Path) -> Option<(String, std::pa
             continue;
         }
         let parts: Vec<u64> = name.split('.').map(|p| p.parse().unwrap_or(0)).collect();
-        let codex = entry.path().join("Codex.exe");
-        if !codex.exists() {
+        let Some(exe) = proxy::app_exe_in(&entry.path()) else {
             continue;
-        }
+        };
         match &best {
-            None => best = Some((parts, name, codex)),
-            Some((cur, _, _)) if parts > *cur => best = Some((parts, name, codex)),
+            None => best = Some((parts, name, exe)),
+            Some((cur, _, _)) if parts > *cur => best = Some((parts, name, exe)),
             _ => {}
         }
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,4 +1,4 @@
-//! Proxy-mode runtime: resolve the newest installed Codex.exe (self-healing
+//! Proxy-mode runtime: resolve the newest installed app shell (self-healing
 //! the `versions/current` junction if needed) and spawn it with the caller's
 //! args + inherited env. We always spawn — Codex's own chromium-derived
 //! ProcessSingleton handles the "already running, focus instead" case via
@@ -6,10 +6,36 @@
 //! hidden message window so we can warn the user if a *foreign* Codex
 //! install is currently the lock holder (their window will get focused
 //! instead of ours).
+//!
+//! Mid-2026 OpenAI renamed the Electron shell from `Codex.exe` to
+//! `ChatGPT.exe` (Store product id and ProductName "Codex" unchanged).
+//! Older version trees only ship `Codex.exe`; newer ones ship `ChatGPT.exe`
+//! plus a leftover non-shell `Codex.exe`. Prefer `ChatGPT.exe` when both
+//! exist.
 
 use crate::config::Config;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+
+/// Electron shell filenames under `versions/<ver>/`, preferred first.
+pub const APP_EXE_CANDIDATES: &[&str] = &["ChatGPT.exe", "Codex.exe"];
+
+/// Process image basenames (lowercase) used by the shell and its Chromium
+/// multi-process children. The CLI helper at `resources/codex.exe` also
+/// matches `codex.exe` — path filtering is still required for "ours" checks.
+const APP_PROCESS_NAMES: &[&str] = &["chatgpt.exe", "codex.exe"];
+
+/// Resolve the real Electron shell inside a single version directory.
+/// Prefers `ChatGPT.exe` over a co-located stub/legacy `Codex.exe`.
+pub fn app_exe_in(dir: &Path) -> Option<PathBuf> {
+    for name in APP_EXE_CANDIDATES {
+        let p = dir.join(name);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
 
 /// Same self-heal as the installer Launch button — delegates to
 /// `main::latest_codex_exe` so the logic lives in one place.
@@ -113,15 +139,19 @@ pub fn find_singleton_holder(_user_data_dir: &Path) -> Option<SingletonHolder> {
     None
 }
 
-/// Spawn Codex.exe with forwarded args. Always spawns — Codex's own
+/// Spawn the app shell with forwarded args. Always spawns — Codex's own
 /// ProcessSingleton handles the "already running" case via pipe handoff,
 /// transferring focus to the lock-holder. Before spawning we check the
 /// singleton; if a *foreign* install holds it, we MessageBox the user so
 /// they understand why their click may surface that other install's window
 /// instead of ours.
 pub fn launch(root: &Path, cfg: &Config, forward_args: &[String]) -> Result<()> {
-    let exe = resolve_codex_exe(root, cfg.use_current_junction)
-        .ok_or_else(|| anyhow::anyhow!("no installed Codex.exe found under {}", root.display()))?;
+    let exe = resolve_codex_exe(root, cfg.use_current_junction).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no installed ChatGPT.exe/Codex.exe found under {}",
+            root.display()
+        )
+    })?;
 
     if let Some(udd) = codex_user_data_dir() {
         if let Some(holder) = find_singleton_holder(&udd) {
@@ -163,11 +193,11 @@ pub fn launch(root: &Path, cfg: &Config, forward_args: &[String]) -> Result<()> 
     Ok(())
 }
 
-/// Terminate every `Codex.exe` process whose image path is NOT under
+/// Terminate every app-shell process whose image path is NOT under
 /// `versions_root`. We confirm the holder is foreign first, then sweep
-/// every other Codex.exe (children share the same foreign image). Waits
-/// up to 5s per PID for exit so the new spawn doesn't race a still-alive
-/// holder.
+/// every other matching process (children share the same foreign image).
+/// Waits up to 5s per PID for exit so the new spawn doesn't race a
+/// still-alive holder.
 #[cfg(windows)]
 fn kill_foreign_codex(holder: &SingletonHolder, versions_root: &Path) {
     let mut to_kill = Vec::new();
@@ -206,11 +236,12 @@ fn path_starts_with_ci(path: &Path, prefix: &Path) -> bool {
 #[cfg(not(windows))]
 fn kill_foreign_codex(_holder: &SingletonHolder, _versions_root: &Path) {}
 
-/// PIDs of every Codex-named process whose image is under `versions_root`
+/// PIDs of every app-shell process whose image is under `versions_root`
 /// (i.e. belongs to *this* install — main, renderers, GPU, utility, the
 /// lowercase CLI helper at `resources/codex.exe`, etc.). Used by the
-/// uninstaller to terminate only our processes, not foreign installs or
-/// unrelated `codex.exe` binaries.
+/// uninstaller / updater to terminate only our processes, not foreign
+/// installs, the Microsoft Store ChatGPT app, or unrelated `codex.exe`
+/// binaries.
 #[cfg(windows)]
 pub fn find_our_codex_pids(versions_root: &Path) -> Vec<u32> {
     find_codex_pids()
@@ -256,13 +287,18 @@ fn process_image_path(pid: u32) -> Option<PathBuf> {
     }
 }
 
-/// Walk the process table collecting PIDs of every process named `Codex.exe`.
-/// Electron apps fork multiple processes (main + renderer + GPU + utility),
-/// all typically sharing the same exe name — callers that intend to terminate
-/// Codex should kill every PID returned here, not just the first.
+/// Walk the process table collecting PIDs of every process named like the
+/// Electron shell (`ChatGPT.exe` or `Codex.exe`). Electron apps fork multiple
+/// processes (main + renderer + GPU + utility), all typically sharing the
+/// same exe name — callers that intend to terminate the app should kill every
+/// PID returned here, not just the first.
 ///
-/// We skip our own PID so a hypothetical rename of the launcher to Codex.exe
-/// wouldn't self-match.
+/// Prefer [`find_our_codex_pids`] when an install root is known: a system-wide
+/// match also hits the official Microsoft Store ChatGPT app and the CLI helper
+/// `resources/codex.exe`.
+///
+/// We skip our own PID so a hypothetical rename of the launcher wouldn't
+/// self-match.
 #[cfg(windows)]
 pub fn find_codex_pids() -> Vec<u32> {
     use windows::Win32::Foundation::CloseHandle;
@@ -271,7 +307,6 @@ pub fn find_codex_pids() -> Vec<u32> {
         TH32CS_SNAPPROCESS,
     };
 
-    let target = "codex.exe";
     let current_pid = std::process::id();
     let mut pids = Vec::new();
 
@@ -294,7 +329,7 @@ pub fn find_codex_pids() -> Vec<u32> {
                         .unwrap_or(entry.szExeFile.len());
                     let name =
                         String::from_utf16_lossy(&entry.szExeFile[..end]).to_ascii_lowercase();
-                    if name == target {
+                    if APP_PROCESS_NAMES.iter().any(|t| name == *t) {
                         pids.push(entry.th32ProcessID);
                     }
                 }

--- a/src/shortcut.rs
+++ b/src/shortcut.rs
@@ -1,9 +1,10 @@
 //! Start Menu `.lnk` creation + refresh via `IShellLinkW` / `IPersistFile`.
 //!
 //! Target = `<root>\codex-launcher.exe` (stable path — shortcut survives
-//! version bumps). IconLocation points at a real `Codex.exe` so the Start
-//! Menu renders Codex's own icon. On update we rewrite the shortcut to
-//! retarget the icon at the newest version's `Codex.exe`.
+//! version bumps). IconLocation points at the real app shell (`ChatGPT.exe`
+//! or legacy `Codex.exe`) so the Start Menu renders the app's own icon. On
+//! update we rewrite the shortcut to retarget the icon at the newest
+//! version's shell.
 
 use crate::config::InstallMode;
 use anyhow::{Context, Result};


### PR DESCRIPTION
OpenAI renamed the desktop Electron shell from Codex.exe to ChatGPT.exe while keeping Store product id 9PLM9XGG6VKS. Launch, extract validation, shortcuts, and process matching now prefer ChatGPT.exe and fall back to Codex.exe for older builds. Update kill is scoped to this install.

Test plan
- [x] Build successfully and use normally